### PR TITLE
Replace the unnecessary images with icons in the role panels

### DIFF
--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { User, UserCheck, Users } from 'react-feather';
 import RolePanel from './role-panel/RolePanel';
 
 const Dashboard = () => {
@@ -87,21 +88,21 @@ const Dashboard = () => {
         </div>
       </div>
       <RolePanel
-        icon="https://randomuser.me/api/portraits/women/29.jpg"
+        Icon={ User }
         title="Supervisor"
         description="Manage supervisor for each team"
         peoples={ supervisors }
         remainingPeoplesCount={ 20 }
       />
       <RolePanel
-        icon="https://randomuser.me/api/portraits/men/3.jpg"
+        Icon={ UserCheck }
         title="Human Resource"
         description="Manage human resource team"
         peoples={ humanResource }
         remainingPeoplesCount={ 14 }
       />
       <RolePanel
-        icon="https://randomuser.me/api/portraits/women/32.jpg"
+        Icon={ Users }
         title="Employee"
         description="Manage employees of the organization"
         peoples={ employees }

--- a/src/components/dashboard/role-panel/RolePanel.jsx
+++ b/src/components/dashboard/role-panel/RolePanel.jsx
@@ -3,7 +3,7 @@ import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 
 const RolePanel = ({
-  icon,
+  Icon,
   title,
   description,
   peoples,
@@ -12,8 +12,8 @@ const RolePanel = ({
   <div className="card bg-light mt-3">
     <div className="card-body">
       <div className="row">
-        <div className="col-auto">
-          <img className="rounded dashboard-listing-icon" src={ icon } alt="Supervisors" />
+        <div className="col-auto text-primary">
+          <Icon size={ 50 } />
         </div>
         <div className="col">
           <div className="row">
@@ -57,7 +57,7 @@ const RolePanel = ({
 ));
 
 RolePanel.propTypes = {
-  icon: PropTypes.string.isRequired,
+  Icon: PropTypes.elementType.isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   peoples: PropTypes.arrayOf(PropTypes.shape({


### PR DESCRIPTION
Closes #18 

- These images are not required there
- Use icons instead to keep the interface looking good

Let me know @sijusamson if the icons need to be changed 😋